### PR TITLE
Corrigido bug em palavras com espaços

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -395,6 +395,10 @@ function addFailCount() {
 function checkPanel(evt, panels) {
   if (testKey(evt.key) || getValue(evt)) {
     for (let i = 0; i < currGame.word.length; i++) {
+      if (panels[i].classList.contains("blank-item")) {
+        continue;
+      }
+
       if (panels[i].textContent !== "") {
         continue;
       } else {


### PR DESCRIPTION
Palavras compostas que possuiam espaço não estavam encerrando o jogo quando o usuário as preenchiam completamente, pois a condição de para estava levando em conta espaços em branco obrigatórios na palavra.