### PR TITLE
Dev

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,8 +136,9 @@ function generateKeyboard() {
     virtualKeyboard.appendChild(btn);
 
     if (key === "P" || key === "Ç") {
-      let br = document.createElement("br");
-      virtualKeyboard.appendChild(br);
+      let line = document.createElement("span");
+      line.classList.add("blank-line");
+      virtualKeyboard.appendChild(line);
     }
   }
 

--- a/styles/game.css
+++ b/styles/game.css
@@ -91,6 +91,7 @@
 
 .letter-item {
   padding: 0.5rem 1rem;
+  min-height: 3.125rem;
 
   text-align: center;
   font-size: 1.5rem;
@@ -109,20 +110,33 @@
   box-shadow: none;
 }
 
+.virtual-keyboard {
+  text-align: center;
+}
+
 .virtual-key {
-  min-width: 2rem;
+  min-width: 1.875rem;
   margin: .125rem;
-  padding: .5rem;
+  padding: .5rem .35rem;
   background-color: var(--c-black);
+
   border: none;
   border-radius: .25rem;
+
   color: var(--c-orange);
-  font-size: 1.25rem;
+  font-size: 1rem;
   font-weight: bold;
+
   transition: all .3s ease-in-out;
 }
 
+.blank-line {
+  display: block;
+  width: 100%;
+  height: .25rem;
+}
+
 .virtual-key:hover, .virtual-key:active, .virtual-key:focus {
-  transform: scale(1.15 );
+  transform: scale(1.07 );
   background-color: var(--c-black-l);
 }


### PR DESCRIPTION
# Ajuste na quebra de layout do teclado virtual

* Devido ao mau comportamento da renderização das teclas virtuais em dispositivos com telas pequenas, o tamanho das teclas virtuais foi reduzido de forma significativa para um tamanho que não causasse a quebra inadequada de uma linha (mas que mantesse a legibilidade das teclas).
  - A animação ao pressionar as teclas também foi ligeiramente ajustada para uma transição menor de tamanho
 
* As quebras de linhas nas teclas **P** e **Ç** com elementos `<br />` foram substituídas por elementos `<span>` para manipulação de espaçamentos entre cada linha.
